### PR TITLE
added storage class to mongo pvc

### DIFF
--- a/kubernetes/Razee/resource.yaml
+++ b/kubernetes/Razee/resource.yaml
@@ -34,6 +34,7 @@ items:
   spec:
     accessModes:
       - ReadWriteOnce
+    storageClassName: manual
     resources:
       requests:
         storage: 3Gi


### PR DESCRIPTION
Trying to create the mongo pvc, it seems that storage class definition is missing from pvc definition