### PR TITLE
Add steps to support EKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ To deploy Razee in your cluster, your cluster must meet the following requiremen
     {"name":"/","parseUA":false,"excludes":["req-headers","res-headers","referer","url","body","short-body"],"hostname":"razeedash-api-55fd67ddb9-cnbf4","pid":16,"level":30,"msg":"Created new collection messages index messages","time":"2019-05-22T03:15:14.253Z","v":0}
     {"name":"razeedash-api","hostname":"razeedash-api-55fd67ddb9-cnbf4","pid":16,"level":30,"msg":"razeedash-api listening on port 3333","time":"2019-05-22T03:15:14.257Z","v":0}
     ```
-    <!--Markdownlint-enable MD013-->
 
 5. Retrieve the **EXTERNAL-IP** of your `razeedash-lb` and `razeedash-api-lb`
  load balancer services and create a RazeeDash config map. The two load balancer
@@ -236,6 +235,7 @@ To deploy Razee in your cluster, your cluster must meet the following requiremen
      --from-literal=root_url=http://"${RAZEEDASH_LB}":8080/ \
      --from-literal=razeedash_api_url=http://"${RAZEEDASH_API_LB}":8081/
    ```
+    <!--Markdownlint-enable MD013-->
 
 6. Verify that all Razee components are deployed and show `1/1` in the **READY**
 column of your CLI output.

--- a/README.md
+++ b/README.md
@@ -225,8 +225,13 @@ To deploy Razee in your cluster, your cluster must meet the following requiremen
  Note the required trailing '/' at the end of `root_url` and `razeedash_api_url`
 
    ```bash
-   RAZEEDASH_LB=$(kubectl get service razeedash-lb -n razee -o jsonpath="{.status.loadBalancer.ingress[*].ip}")
-   RAZEEDASH_API_LB=$(kubectl get service razeedash-api-lb -n razee -o jsonpath="{.status.loadBalancer.ingress[*].ip}")
+   # EKS uses hostname, IKS uses ip on the ingress.  This will handle both.
+   RAZEEDASH_LB_IP=$(kubectl get service razeedash-lb -n razee -o jsonpath="{.status.loadBalancer.ingress[*].ip}")
+   RAZEEDASH_API_LB_IP=$(kubectl get service razeedash-api-lb -n razee -o jsonpath="{.status.loadBalancer.ingress[*].ip}")
+   RAZEEDASH_LB_HOSTNAME=$(kubectl get service razeedash-lb -n razee -o jsonpath="{.status.loadBalancer.ingress[*].hostname}")
+   RAZEEDASH_API_LB_HOSTNAME=$(kubectl get service razeedash-api-lb -n razee -o jsonpath="{.status.loadBalancer.ingress[*].hostname}")
+   RAZEEDASH_LB = ${RAZEEDASH_LB_HOSTNAME} && [[ "${RAZEEDASH_LB_IP}" != "" ]] && RAZEEDASH_LB = ${RAZEEDASH_LB_IP}
+   RAZEEDASH_API_LB = ${RAZEEDASH_LB_API_HOSTNAME} && [[ "${RAZEEDASH_LB_API_IP}" != "" ]] && RAZEEDASH_API_LB = ${RAZEEDASH_LB_API_IP}
    kubectl create configmap razeedash-config -n razee \
      --from-literal=root_url=http://"${RAZEEDASH_LB}":8080/ \
      --from-literal=razeedash_api_url=http://"${RAZEEDASH_API_LB}":8081/


### PR DESCRIPTION
Step 5 when looking for the load balancer for EKS uses `hostname` instead of how IKS uses `ip`.  Updated instructions to support both automagically.