### PR TITLE
Update razeedash.yaml apiVersion

### DIFF
--- a/kubernetes/Razee/razeedash.yaml
+++ b/kubernetes/Razee/razeedash.yaml
@@ -8,7 +8,7 @@ metadata:
     razee.io/commit-sha: "{{TRAVIS_COMMIT}}"
 items:
 # Razeedash resources
-- apiVersion: "deploy.razee.io/v1alpha1"
+- apiVersion: "deploy.razee.io/v1alpha2"
   kind: RemoteResource
   metadata:
     name: razeedash


### PR DESCRIPTION
Looks like this was fixed for the `razeedash-all-in-one.yaml` and not the `razeedash.yaml` file in GH-148 for GH-146

Fixes the following error:

> Error: razee/razeedash failed to create kubernetes rest client for update of resource: resource [deploy.razee.io/v1alpha1/RemoteResource] isn't valid for cluster, check the APIVersion and Kind fields are valid